### PR TITLE
chore: improve development environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,14 @@
 # Laravel storageディレクトリを除外
 /storage/
 
+# Node.js の依存ディレクトリを除外
+**/node_modules/
+
+# Composer の vendor ディレクトリを除外
+**/vendor/
+
+# 環境変数ファイルを除外
+.env
+
 # Macの隠しファイルを除外
 *.DS_Store

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -33,7 +33,6 @@ RUN mkdir -p /var/www/html/storage/framework/{sessions,views,cache}
 # 権限の設定
 RUN chown -R www-data:www-data /var/www/html/storage /var/www/html/bootstrap/cache
 RUN chmod -R 777 /var/www/html/storage /var/www/html/bootstrap/cache
-RUN chown -R www-data:www-data /var/www/html/storage /var/www/html/bootstrap/cache
 
 # コンテナ内で PHP-FPM がリッスンするポート（※通常は内部ポートとして使用）
 EXPOSE 9000


### PR DESCRIPTION
## Summary
- ignore node_modules, vendor, and .env files
- remove redundant permission step in app Dockerfile

## Testing
- `npm test` *(fails: Missing script "test")*
- `php artisan test` *(fails: Failed to open required '/workspace/Gizhub/app/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b54cdff058832086f295f03f8b98b5